### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 ---
 name: Test VPN
+permissions:
+  contents: read
 on:
   - push
   - workflow_dispatch


### PR DESCRIPTION
Potential fix for [https://github.com/reload/vpn-action/security/code-scanning/1](https://github.com/reload/vpn-action/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to the workflow, preferably at the top level (root), unless individual jobs need different permissions. As this workflow does not appear to require any write access (there are no steps that push code, create issues, modify pull requests, etc.), the most restrictive appropriate setting is `contents: read`. This should be added immediately below the `name` block (recommended for workflow-wide default) or to the job if job-specific permissions are required. No further permissions are needed. Only add or modify the `permissions` field—do not change or remove any functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
