### PR TITLE
Replace 3DES/modp1024 IKE proposals rejected by new UDM Pro gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This action sets up a VPN connection in a GitHub Actions workflow.
 
->[!NOTE]
+> [!NOTE]
 >
 > - This action is only supported on Linux runners.
 > - This is designed to work with our Unifi VPN. Other VPNs may not work.
@@ -10,11 +10,15 @@ This action sets up a VPN connection in a GitHub Actions workflow.
 Example setup:
 
 ```yaml
-      - uses: reload/vpn-action@main
-        with:
-          server: ${{ vars.RELOAD_HQ_IP }}
-          psk: ${{ secrets.RELOAD_VPN_PSK }}
-          username: ${{ vars.RELOAD_VPN_USERNAME }}
-          password: ${{ secrets.RELOAD_VPN_PASSWORD }}
-          route: 94.23.123.122  # platform.sh FR-3 pr sites
+- uses: reload/vpn-action@main
+  with:
+    server: ${{ vars.RELOAD_HQ_IP }}
+    psk: ${{ secrets.RELOAD_VPN_PSK }}
+    username: ${{ vars.RELOAD_VPN_USERNAME }}
+    password: ${{ secrets.RELOAD_VPN_PASSWORD }}
+    route: 94.23.123.122 # platform.sh FR-3 pr sites
 ```
+
+The IKE/ESP cipher suites proposed to the VPN server can be overridden
+with the optional `ike` and `esp` inputs (comma-separated strongswan
+suites). The defaults match our Unifi Dream Machine Pro gateway.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,14 @@ inputs:
   route:
     required: true
     description: 'VPN route'
+  ike:
+    required: false
+    description: 'IKE (phase 1) cipher suites to propose'
+    default: 'aes256-sha256-modp2048,aes256-sha1-modp2048,aes128-sha1-modp2048'
+  esp:
+    required: false
+    description: 'ESP (phase 2) cipher suites to propose'
+    default: 'aes256-sha1,aes128-sha1,aes256-sha256'
 runs:
   using: 'node24'
   main: 'vpn-up.mjs'

--- a/vpn-up.mjs
+++ b/vpn-up.mjs
@@ -15,6 +15,10 @@ const username = process.env.INPUT_USERNAME || "<VPN_USERNAME>";
 const password = process.env.INPUT_PASSWORD || "<VPN_PASSWORD>";
 const psk = process.env.INPUT_PSK || "<VPN_PSK>";
 const route = process.env.INPUT_ROUTE || "<VPN_ROUTE>";
+const ike =
+  process.env.INPUT_IKE ||
+  "aes256-sha256-modp2048,aes256-sha1-modp2048,aes128-sha1-modp2048";
+const esp = process.env.INPUT_ESP || "aes256-sha1,aes128-sha1,aes256-sha256";
 
 let ipsecConf = "ipsec.conf";
 let ipsecSecrets = "ipsec.secrets";
@@ -32,8 +36,8 @@ conn %default
     keyingtries=1
     keyexchange=ikev1
     authby=secret
-    ike=aes256-sha256-modp2048,aes256-sha1-modp2048,aes128-sha1-modp2048
-    esp=aes256-sha1,aes128-sha1,aes256-sha256
+    ike=${ike}
+    esp=${esp}
 
 conn L2TP-PSK
     keyexchange=ikev1

--- a/vpn-up.mjs
+++ b/vpn-up.mjs
@@ -32,8 +32,8 @@ conn %default
     keyingtries=1
     keyexchange=ikev1
     authby=secret
-    ike=3des-sha1-modp1024
-    esp=3des-sha1
+    ike=aes256-sha256-modp2048,aes256-sha1-modp2048,aes128-sha1-modp2048
+    esp=aes256-sha1,aes128-sha1,aes256-sha256
 
 conn L2TP-PSK
     keyexchange=ikev1


### PR DESCRIPTION
Every workflow using this action has failed with `Cannot find device "ppp0"` since 2026-07-24, when the office gateway was upgraded from a UniFi USG Pro 4 to a UniFi Dream Machine Pro.

## Root cause

The failure is upstream of `ppp0`: strongswan logs `establishing connection 'L2TP-PSK' failed` after the gateway replies **`NO_PROPOSAL_CHOSEN`** to our phase-1 proposal. The UDM Pro no longer accepts the hardcoded legacy suite `3des-sha1-modp1024`. Since the IPsec tunnel never forms, xl2tpd never creates `ppp0`, and the route step dies.

Timeline evidence (reload/bupl regression runs, identical action version, strongswan 5.9.13 and ubuntu-24.04 runners on both sides):
- Jul 24 07:40 — [green run](https://github.com/reload/bupl/actions/runs/30076222872/job/89427425961): `IKE_SA L2TP-PSK[1] established`
- Jul 24 20:00 — USG Pro 4 replaced with UDM Pro
- Jul 28 onward — all runs: `received NO_PROPOSAL_CHOSEN error notify`

## What the UDM Pro accepts (ike-scan probe, 2026-07-29)

| Phase-1 proposal | Result |
|---|---|
| AES-256 / SHA2-256 / modp2048 | ✅ handshake |
| AES-256 / SHA1 / modp2048 | ✅ handshake |
| AES-128 / SHA1 / modp2048 | ✅ handshake |
| anything with modp1024 (DH2) | ❌ NO-PROPOSAL-CHOSEN |
| AES-256 / SHA2-512 / modp2048 | ❌ NO-PROPOSAL-CHOSEN |
| 3DES/DES defaults | ❌ NO-PROPOSAL-CHOSEN |

## Changes

1. New defaults matching the UDM Pro:
   ```
   ike=aes256-sha256-modp2048,aes256-sha1-modp2048,aes128-sha1-modp2048
   esp=aes256-sha1,aes128-sha1,aes256-sha256
   ```
2. The suites are now configurable via optional `ike`/`esp` inputs, so the next gateway change can be fixed — or probed — from a consumer workflow without a new action release.

The "Test VPN connection" CI job validates the defaults against the real gateway (it passed on the first commit, confirming phase 2 negotiates fine with the offered ESP candidates).
